### PR TITLE
Remove an obsolete webrtc parameter

### DIFF
--- a/lib/ssh-session.js
+++ b/lib/ssh-session.js
@@ -92,12 +92,10 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
                 debug('Will open peer connection with stun', this.stun, 'turn', this.turn);
                 this.wrtc.RTCPeerConnection({
                     iceServers: [{
-                            urls: this.stun,
-                            url: this.stun
+                            urls: this.stun
                         },
                         {
                             urls: this.turn,
-                            url: this.turn,
                             username: this.username,
                             credential: this.password
                         }

--- a/lib/ssh-session.js
+++ b/lib/ssh-session.js
@@ -1,6 +1,7 @@
 let wrtc = require('./webrtc-request');
 let Uuid = require('uuid');
 let debug = require('debug')('Unifi SSH');
+debug.log = console.log.bind(console);
 
 function SSHSession(unifi, mac, uuid, stun, turn, username, password, site, autoclose, webrtc, waiter) {
     this.unifi = unifi;

--- a/lib/ssh-session.js
+++ b/lib/ssh-session.js
@@ -81,11 +81,13 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
                         this.password = d.password;
                     }
                 }
+                debug("Building ssh session with params: mac=' + this.mac + ' uuid=' + this.uuid + ' ttl=-1 stun=' + (this.stun instanceof Array && this.stun[0] ? this.stun[0].replace(/stun:/, '') : this.stun) + ' turn=' + (this.turn instanceof Array && this.turn[0] ? this.turn[0].replace(/turn:/, '') : this.turn) + ' username='+this.username + ' password=' + this.password + ' site=' + this.site);
                 return this.unifi.buildSSHSession(this.mac, this.uuid, "-1", (this.stun instanceof Array && this.stun[0] ? this.stun[0].replace(/stun:/, '') : this.stun), (this.turn instanceof Array && this.turn[0] ? this.turn[0].replace(/turn:/, '') : this.turn), this.username, this.password, this.site);
             });
         }
         firstCall
-            .then(() => {
+            .then((r) => {
+                debug("first call response: " + stringify(r));
                 let o = { debug: this.debug };
                 if (this.waiter) o.waiter = this.waiter;
                 if (this.webrtc) o.webrtc = this.webrtc;

--- a/lib/ssh-session.js
+++ b/lib/ssh-session.js
@@ -81,7 +81,7 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
                         this.password = d.password;
                     }
                 }
-                debug("Building ssh session with params: mac=' + this.mac + ' uuid=' + this.uuid + ' ttl=-1 stun=' + (this.stun instanceof Array && this.stun[0] ? this.stun[0].replace(/stun:/, '') : this.stun) + ' turn=' + (this.turn instanceof Array && this.turn[0] ? this.turn[0].replace(/turn:/, '') : this.turn) + ' username='+this.username + ' password=' + this.password + ' site=' + this.site);
+                debug('Building ssh session with params: mac=' + this.mac + ' uuid=' + this.uuid + ' ttl=-1 stun=' + (this.stun instanceof Array && this.stun[0] ? this.stun[0].replace(/stun:/, '') : this.stun) + ' turn=' + (this.turn instanceof Array && this.turn[0] ? this.turn[0].replace(/turn:/, '') : this.turn) + ' username='+this.username + ' password=' + this.password + ' site=' + this.site);
                 return this.unifi.buildSSHSession(this.mac, this.uuid, "-1", (this.stun instanceof Array && this.stun[0] ? this.stun[0].replace(/stun:/, '') : this.stun), (this.turn instanceof Array && this.turn[0] ? this.turn[0].replace(/turn:/, '') : this.turn), this.username, this.password, this.site);
             });
         }

--- a/lib/ssh-session.js
+++ b/lib/ssh-session.js
@@ -92,7 +92,7 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
                 debug('Will open peer connection with stun', this.stun, 'turn', this.turn);
                 this.wrtc.RTCPeerConnection({
                     iceServers: [{
-                            urls: this.stun
+                            urls: [ this.stun ]
                         },
                         {
                             urls: this.turn,

--- a/lib/ssh-session.js
+++ b/lib/ssh-session.js
@@ -108,8 +108,8 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
                     ]
                 }); // ICE Servers
                 let connStateChange = () => {
-                    debug('CAREFUL, Connection state changed');
                     let state = this.wrtc.peer.iceConnectionState;
+                    debug('CAREFUL, Connection state changed: ' + state);
                     if (state == 'disconnected' || state == 'failed') {
                         debug('We are notified for session disconnection');
                         let rej = this.state != "open";

--- a/lib/ssh-session.js
+++ b/lib/ssh-session.js
@@ -160,12 +160,15 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
                 });
             })
             .then((data) => {
+                debug("Remote description was set: " + JSON.stringify(data) + "; creating answer");
                 return this.wrtc.createAnswer(data);
             })
             .then((data) => {
+                debug("Answer was created: " + JSON.stringify(data) + "; setting local description");
                 return this.wrtc.setLocalDescription(data);
             })
             .then((sdpData) => {
+                debug("Local description was set: " + JSON.stringify(sdpData) + "; collecting ICE candidates");
                 return this.wrtc.collectIceCandidates(sdpData);
             })
             .then((data) => {
@@ -181,6 +184,7 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
                         return x > y;
                     }).shift();
                 let ip = line.match(/udp\s+\d+\s+(\S+)\s/)[1];
+                debug("Executing ssh-sdp-answer with sdp=" + sdp);
                 return this.unifi.sshSDPAnswer(this.mac, this.uuid, /*sdp.replace("c=IN IP4 0.0.0.0", "c=IN IP4 " + ip) */ sdp, this.site);
             })
             //            .then((data) => {
@@ -188,6 +192,7 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
             //            })
             .then((data) => {
                 debug('Channel is supposed to be open now. Lets wait');
+                debug('Set timeout: ' + (connectTimeout || this.connectTimeout || 15000));
                 timeoutChannel = setTimeout(() => {
                     debug('Timeout has passed without response, the channel is not open');
                     this.unifi.closeSSHSession(this.mac, this.uuid, this.site)

--- a/lib/ssh-session.js
+++ b/lib/ssh-session.js
@@ -192,7 +192,7 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
                 return this.wrtc.openDataChannel('ssh');
             })
             .then((data) => {
-                debug('Channel is supposed to be open now. Lets wait');
+                debug('Channel is supposed to be open now. Lets wait: ' + JSON.stringify(data));
                 debug('Set timeout: ' + (connectTimeout || this.connectTimeout || 15000));
                 timeoutChannel = setTimeout(() => {
                     debug('Timeout has passed without response, the channel is not open');

--- a/lib/ssh-session.js
+++ b/lib/ssh-session.js
@@ -149,6 +149,17 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
                         this.fireQ('onmessage', event);
                     };
                 });
+                this.wrtc.setCallback('onnegotiationneeded', (event) => {
+                    debug("Handling negotiation needed event.");
+                    this.wrtc.createOffer()
+                    .then((offer) => {
+                        debug("Negotiation offer created: " + JSON.stringify(offer));
+                        return this.wrtc.setLocalDescription(offer);
+                    })
+                    .catch((err) => {
+                        debug("Error while negotiating: " + err);
+                    });
+                });
                 return this.unifi.getSDPOffer(this.mac, this.uuid, this.site);
             })
             .then((data) => {

--- a/lib/ssh-session.js
+++ b/lib/ssh-session.js
@@ -93,7 +93,7 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
                 debug('Will open peer connection with stun', this.stun, 'turn', this.turn);
                 this.wrtc.RTCPeerConnection({
                     iceServers: [{
-                            urls: [ this.stun ]
+                            urls: this.stun
                         },
                         {
                             urls: this.turn,

--- a/lib/ssh-session.js
+++ b/lib/ssh-session.js
@@ -187,9 +187,10 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
                 debug("Executing ssh-sdp-answer with sdp=" + sdp);
                 return this.unifi.sshSDPAnswer(this.mac, this.uuid, /*sdp.replace("c=IN IP4 0.0.0.0", "c=IN IP4 " + ip) */ sdp, this.site);
             })
-            //            .then((data) => {
-            //                return this.wrtc.openDataChannel('ssh');
-            //            })
+            .then((data) => {
+                debug('ssh-sdp-answer is completed with response: ' + JSON.stringify(data) + '; openning data channel');
+                return this.wrtc.openDataChannel('ssh');
+            })
             .then((data) => {
                 debug('Channel is supposed to be open now. Lets wait');
                 debug('Set timeout: ' + (connectTimeout || this.connectTimeout || 15000));

--- a/lib/ssh-session.js
+++ b/lib/ssh-session.js
@@ -87,7 +87,7 @@ SSHSession.prototype.connect = function(connectTimeout, closeCallBack) {
         }
         firstCall
             .then((r) => {
-                debug("first call response: " + stringify(r));
+                debug("first call response: " + JSON.stringify(r));
                 let o = { debug: this.debug };
                 if (this.waiter) o.waiter = this.waiter;
                 if (this.webrtc) o.webrtc = this.webrtc;

--- a/lib/webrtc-request.js
+++ b/lib/webrtc-request.js
@@ -192,6 +192,11 @@ class WRTC {
                     this.log('Candidate is empty, terminate the gathering');
                     data.sdp = sdp;
                     return resolve(data);
+                }
+                if (candidate.candidate.type === 'relay') {
+                    this.log('Candidate type is relay, terminate the gathering');
+                    data.sdp = sdp;
+                    return resolve(data);
                 } // TODO: implement reject
                 if (candidate && candidate.candidate) {
                     let cand = candidate.candidate;
@@ -200,7 +205,7 @@ class WRTC {
                     //if (cand.candidate.match(/fd13/)) return; // Ignore IPv6 for the moment
                     sdp = sdp.replace(/\r\n/g, '\n');
                     for (var b, c, d = sdp, e = 0, f = 0, g = /m=[^\n]*\n/g; null !== (b = g.exec(d));) {
-                        if (f >= cand.sdpMLineIndex) {
+                        if (f === cand.sdpMLineIndex) {
                             return c = b.index,
                                 b = g.exec(d),
                                 e = null !== b ? b.index : -1,

--- a/lib/webrtc-request.js
+++ b/lib/webrtc-request.js
@@ -17,6 +17,7 @@ class WRTC {
         this._q = {};
         this._channel = {};
         this.log = require('debug')(this.debugName || 'WRTCRequest');
+        this.log.log = console.log.bind(console);
         if (this.debug) this.log.enabled = true;
         if (this.webrtc && this.webrtc.on) {
             this.webrtc.on('error', error => {

--- a/lib/webrtc-request.js
+++ b/lib/webrtc-request.js
@@ -131,7 +131,7 @@ class WRTC {
                     w,
                     (data) => { // Create Answer
                         this.log('received answer from setting remote description: ' + JSON.stringify(data));
-                        resolve(data /*|| desc*/ );
+                        resolve(data || desc); // data is always null
                     },
                     (err) => {
                         this.log('error while trying to set remote description: ' + err);

--- a/lib/webrtc-request.js
+++ b/lib/webrtc-request.js
@@ -130,9 +130,13 @@ class WRTC {
                 this.peer.setRemoteDescription(
                     w,
                     (data) => { // Create Answer
+                        this.log('received answer from setting remote description: ' + JSON.stringify(data));
                         resolve(data /*|| desc*/ );
                     },
-                    reject
+                    (err) => {
+                        this.log('error while trying to set remote description: ' + err);
+                        reject(err);
+                    }
                 );
             });
         });

--- a/lib/webrtc-request.js
+++ b/lib/webrtc-request.js
@@ -200,7 +200,7 @@ class WRTC {
                     //if (cand.candidate.match(/fd13/)) return; // Ignore IPv6 for the moment
                     sdp = sdp.replace(/\r\n/g, '\n');
                     for (var b, c, d = sdp, e = 0, f = 0, g = /m=[^\n]*\n/g; null !== (b = g.exec(d));) {
-                        if (f === cand.sdpMLineIndex) {
+                        if (f >= cand.sdpMLineIndex) {
                             return c = b.index,
                                 b = g.exec(d),
                                 e = null !== b ? b.index : -1,

--- a/lib/webrtc-request.js
+++ b/lib/webrtc-request.js
@@ -124,6 +124,7 @@ class WRTC {
             }
             this.log('WEBRTC_SET_REMOTEDESC', desc);
             let w = new this.webrtc.RTCSessionDescription(desc);
+
             wait(this.waiter).then(() => {
                 this.peer.setRemoteDescription(
                     w,


### PR DESCRIPTION
When creating a webrtc connection, do not pass a 'url' property to in the iceservers parameter, as per https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/delian/node-unifiapi/20)
<!-- Reviewable:end -->
