### PR TITLE
fixed kick_sta (Reconnect client)

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ UnifiAPI.prototype.unauthorize_guest = function(mac = '', site = undefined) {
  */
 UnifiAPI.prototype.kick_sta = function(mac = '', site = undefined) {
     return this.netsite('/cmd/stamgr', {
-        cmd: 'kick_sta',
+        cmd: 'kick-sta',
         mac: mac.toLowerCase()
     }, {}, undefined, site);
 };


### PR DESCRIPTION
Hi @delian. The reconnect client (kick_sta) is broken, because this cmd correct is "kick-sta" and not "kick_sta".

Sending kick_sta cmd receiving "api.err.NotFound" .

Congrats by project!

Regards,